### PR TITLE
JWT token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,24 @@ rows = await cur.fetchall()
 await conn.close()
 ```
 
+# JWT Token Authentication
+The `JWTAuthentication` class can be used to connect to a configured Trino cluster:
+```python
+import aiotrino
+conn = aiotrino.dbapi.connect(
+    host='coordinator url',
+    port=8443,
+    catalog='the-catalog',
+    schema='the-schema',
+    http_scheme='https',
+    auth=aiotrino.auth.JWTAuthentication(token="jwt-token"),
+)
+cur = await conn.cursor()
+await cur.execute('SELECT * FROM system.runtime.nodes')
+rows = await cur.fetchall()
+await conn.close()
+```
+
 # Transactions
 The client runs by default in *autocommit* mode. To enable transactions, set
 *isolation_level* to a value different than `IsolationLevel.AUTOCOMMIT`:

--- a/aiotrino/auth.py
+++ b/aiotrino/auth.py
@@ -13,7 +13,8 @@
 import abc
 
 import aiohttp
-
+from typing import Tuple, Any
+# from requests.auth import AuthBase, extract_cookies_to_jar
 
 class Authentication(abc.ABC):  # type: ignore
     @abc.abstractmethod
@@ -121,3 +122,23 @@ class BasicAuthentication(Authentication):
 
     def handle_error(self, handle_error):
         pass
+    
+
+class JWTAuthentication(Authentication):
+
+    def __init__(self, token: str):
+        self.token = token
+
+    def setup(self, trino_client):
+        self.set_client_session(trino_client.client_session)
+        self.set_http_session(trino_client.http_session)
+
+    def set_http_session(self, http_session):
+        http_session.headers["Authorization"] = "Bearer " + self.token
+        return http_session
+    
+    def set_client_session(self, client_session):
+        pass
+
+    def get_exceptions(self) -> Tuple[Any, ...]:
+        return ()


### PR DESCRIPTION
The class is similarly defined as within the original trino python package, and just allows for jwt tokens to be added to trino requests

> Very small and simplistic addition to accommodate tokens. Not to follow OAuth2 code flow etc.

- Updated the auth class to add `JWTAuthentication` class
- Updated readme with connection example for jwt tokens
- tested with connection to company environment deployed Trino cluster (works)

Example request:
```python
import pandas as pd
from datetime import datetime
import aiotrino
from aiotrino.dbapi import Connection

async def do_query(query: str):
        conn : Connection = None
        try:
            conn = aiotrino.dbapi.connect(
                host= 'domain',
                port= 443,
                catalog= 'cat',
                schema= 'default_ml',
                http_scheme= 'https',
                auth=aiotrino.auth.JWTAuthentication(token=token),
                request_timeout=60
                )

            start = datetime.utcnow()
            cur = await conn.cursor()
            await cur.execute(query)
            rows = await cur.fetchall()
            field_names = [i[0] for i in cur.description]
            df = pd.DataFrame(rows, columns=field_names)

            print(f"elapsed: {datetime.utcnow() - start}")
            return df
      
        except Exception as e:
            raise e
        finally:
             if conn != None:
                  await conn.close()
        
await do_query('SHOW TABLES')
```

jupyter notebook output as validation:

![image](https://user-images.githubusercontent.com/7777405/236465595-d4acc641-ce2c-47bb-854d-9e574a0cc68d.png)


